### PR TITLE
Add transformation to snake_case camelCase

### DIFF
--- a/lib/deep_hash_transformer.rb
+++ b/lib/deep_hash_transformer.rb
@@ -8,7 +8,15 @@ class DeepHashTransformer
     identity: ->(val) { val },
     stringify: ->(val) { val.to_s },
     symbolize: ->(val) { val.to_sym },
-    underscore: ->(val) { val.to_s.tr('-', '_') }
+    underscore: ->(val) { val.to_s.tr('-', '_') },
+    snake_case: lambda do |val|
+      val = val.dup.to_s
+      val.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+      val.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+      val.tr!('-', '_')
+      val.downcase!
+      val
+    end
   }.freeze
 
   def initialize(hash)

--- a/spec/deep_hash_transformer_spec.rb
+++ b/spec/deep_hash_transformer_spec.rb
@@ -5,18 +5,18 @@ RSpec.describe DeepHashTransformer do
     described_class.new(
       Integer => 123,
       :foobar => { bar: 'bar' },
-      'aa_zz' => [{ 'bar' => :bar, 'a-z' => 'a-z' }]
+      'aa_zz' => [{ 'bar' => :bar, 'a-z' => 'a-z' }, { 'aZ' => 'aZ' }]
     )
   end
 
   describe '#tr with `:underscore, :symbolize`' do
-    subject { super().tr(:underscore, :symbolize) }
+    subject { super().tr(:snake_case, :symbolize) }
 
     it do
       expect(subject).to eq( # rubocop:disable RSpec/NamedSubject
         Integer => 123,
         :foobar => { bar: 'bar' },
-        :aa_zz => [{ bar: :bar, a_z: 'a-z' }]
+        :aa_zz => [{ bar: :bar, a_z: 'a-z' }, { a_z: 'aZ' }]
       )
     end
   end
@@ -28,7 +28,7 @@ RSpec.describe DeepHashTransformer do
       expect(subject).to eq( # rubocop:disable RSpec/NamedSubject
         Integer => 123,
         'foobar' => { 'bar' => 'bar' },
-        'aa-zz' => [{ 'bar' => :bar, 'a-z' => 'a-z' }]
+        'aa-zz' => [{ 'bar' => :bar, 'a-z' => 'a-z' }, { 'aZ' => 'aZ' }]
       )
     end
   end
@@ -40,7 +40,7 @@ RSpec.describe DeepHashTransformer do
       expect(subject).to eq( # rubocop:disable RSpec/NamedSubject
         Integer => 123,
         :foobar => { bar: 'bar' },
-        'aa_zz' => [{ 'bar' => :bar, 'a-z' => 'a-z' }]
+        'aa_zz' => [{ 'bar' => :bar, 'a-z' => 'a-z' }, { 'aZ' => 'aZ' }]
       )
     end
   end
@@ -52,7 +52,7 @@ RSpec.describe DeepHashTransformer do
       expect(subject).to eq( # rubocop:disable RSpec/NamedSubject
         Integer => 123,
         'foobar' => { 'bar' => 'bar' },
-        'aa_zz' => [{ 'bar' => :bar, 'a-z' => 'a-z' }]
+        'aa_zz' => [{ 'bar' => :bar, 'a-z' => 'a-z' }, { 'aZ' => 'aZ' }]
       )
     end
   end
@@ -64,7 +64,7 @@ RSpec.describe DeepHashTransformer do
       expect(subject).to eq( # rubocop:disable RSpec/NamedSubject
         Integer => 123,
         :foobar => { bar: 'bar' },
-        :aa_zz => [{ bar: :bar, 'a-z': 'a-z' }]
+        :aa_zz => [{ bar: :bar, 'a-z': 'a-z' }, { aZ: 'aZ' }]
       )
     end
   end
@@ -76,7 +76,19 @@ RSpec.describe DeepHashTransformer do
       expect(subject).to eq( # rubocop:disable RSpec/NamedSubject
         Integer => 123,
         'foobar' => { 'bar' => 'bar' },
-        'aa_zz' => [{ 'bar' => :bar, 'a_z' => 'a-z' }]
+        'aa_zz' => [{ 'bar' => :bar, 'a_z' => 'a-z' }, { 'aZ' => 'aZ' }]
+      )
+    end
+  end
+
+  describe '#snake_case' do
+    subject { super().snake_case }
+
+    it do
+      expect(subject).to eq( # rubocop:disable RSpec/NamedSubject
+        Integer => 123,
+        'foobar' => { 'bar' => 'bar' },
+        'aa_zz' => [{ 'bar' => :bar, 'a_z' => 'a-z' }, { 'a_z' => 'aZ' }]
       )
     end
   end


### PR DESCRIPTION
This allows to transform either `dash-case` or `camelCase` keys to be transformed to `snake_case`